### PR TITLE
Implement `Headers::fromRequestHeaders()`

### DIFF
--- a/headers.php
+++ b/headers.php
@@ -155,4 +155,16 @@ class Headers implements HeadersInterface
 			return false;
 		}
 	}
+
+	public static function fromRequestHeaders():? HeadersInterface
+	{
+		if (function_exists('getallheaders')) {
+			$headers = new self(getallheaders());
+			$headers->delete('host');
+			$headers->delete('cookie');
+			return $headers;
+		} else {
+			return null;
+		}
+	}
 }

--- a/headers.php
+++ b/headers.php
@@ -156,13 +156,28 @@ class Headers implements HeadersInterface
 		}
 	}
 
-	public static function fromRequestHeaders():? HeadersInterface
+	public static function fromRequestHeaders(string ...$include):? HeadersInterface
 	{
 		if (function_exists('getallheaders')) {
-			$headers = new self(getallheaders());
-			$headers->delete('host');
-			$headers->delete('cookie');
-			return $headers;
+			if (count($include) === 0) {
+				$headers = new self(getallheaders());
+				$headers->delete('host');
+				$headers->delete('cookie');
+
+				return $headers;
+			} else {
+				$include = array_map('strtolower', $include);
+				$headers = new self();
+
+				foreach (getallheaders() as $key => $value) {
+					$key = strtolower($key);
+					if (in_array($key, $include)) {
+						$headers->set($key, $value);
+					}
+				}
+
+				return $headers;
+			}
 		} else {
 			return null;
 		}

--- a/interfaces/headersinterface.php
+++ b/interfaces/headersinterface.php
@@ -22,5 +22,5 @@ interface HeadersInterface extends Serializable
 
 	public function entries(): iterable;
 
-	public static function fromRequestHeaders():? HeadersInterface;
+	public static function fromRequestHeaders(string ...$include):? HeadersInterface;
 }

--- a/interfaces/headersinterface.php
+++ b/interfaces/headersinterface.php
@@ -21,4 +21,6 @@ interface HeadersInterface extends Serializable
 	public function values(): iterable;
 
 	public function entries(): iterable;
+
+	public static function fromRequestHeaders():? HeadersInterface;
 }


### PR DESCRIPTION
Static method to construct a `Headers` object from request headers, ignoring cookies & host. Can also be used to set from a select list of request headers.

Resolves #5 