### PR TITLE
Implement `URL::requestUrl()`

### DIFF
--- a/interfaces/urlinterface.php
+++ b/interfaces/urlinterface.php
@@ -10,6 +10,8 @@ interface URLInterface extends Serializable
 
 	public function __toString(): string;
 
+	public function jsonSerialize(): string;
+
 	public function getHref(): string;
 
 	public function setHref(string $val): void;

--- a/interfaces/urlinterface.php
+++ b/interfaces/urlinterface.php
@@ -28,7 +28,7 @@ interface URLInterface extends Serializable
 
 	public function setOrigin(string $val): void;
 
-	public function getPort():? string;
+	public function getPort():? int;
 
 	public function setPort(?int $val): void;
 
@@ -36,7 +36,7 @@ interface URLInterface extends Serializable
 
 	public function setPathname(?string $val): void;
 
-	public function getSearch():? string;
+	public function getSearch(): string;
 
 	public function setSearch(?string $val): void;
 
@@ -44,9 +44,9 @@ interface URLInterface extends Serializable
 
 	public function setSearchParams(URLSearchParamsInterface $val): void;
 
-	public function getHash(bool $escape = false):? string;
+	public function getHash(bool $escape = false): string;
 
-	public function setHash(string $val): void;
+	public function setHash(?string $val): void;
 
 	public function getUsername(bool $escape = false):? string;
 
@@ -55,4 +55,6 @@ interface URLInterface extends Serializable
 	public function getPassword(bool $escape = false):? string;
 
 	public function setPassword(?string $val): void;
+
+	public static function requestUrl():? URLInterface;
 }

--- a/interfaces/urlsearchparamsinterface.php
+++ b/interfaces/urlsearchparamsinterface.php
@@ -5,6 +5,8 @@ use \Serializable;
 
 interface URLSearchParamsInterface extends Serializable
 {
+	public function __toString(): string;
+
 	public function append(string $name, string $value): bool;
 
 	public function get(string $name):? string;

--- a/url.php
+++ b/url.php
@@ -71,20 +71,9 @@ class URL implements URLInterface, JsonSerializable
 		];
 	}
 
-	public function jsonSerialize(): array
+	public function jsonSerialize(): string
 	{
-		return [
-			'protocol'     => $this->getProtocol(),
-			'username'     => $this->getUsername(),
-			'password'     => $this->getPassword(),
-			'hostname'     => $this->getHostname(),
-			'port'         => $this->getPort(),
-			'pathname'     => $this->getPathname(),
-			'search'       => $this->getSearch(),
-			'searchParams' => $this->getSearchParams(),
-			'hash'         => $this->getHash(),
-			'href'         => $this->gethref(),
-		];
+		return $this->getHref();
 	}
 
 	public function __toString(): string

--- a/urlsearchparams.php
+++ b/urlsearchparams.php
@@ -3,7 +3,9 @@ namespace shgysk8zer0\HTTP;
 
 use \shgysk8zer0\HTTP\Interfaces\URLSearchParamsInterface;
 
-class URLSearchParams implements URLSearchParamsInterface
+use \JsonSerializable;
+
+class URLSearchParams implements URLSearchParamsInterface, JsonSerializable
 {
 	private $_params = [];
 
@@ -21,6 +23,11 @@ class URLSearchParams implements URLSearchParamsInterface
 	public function __toString(): string
 	{
 		return http_build_query($this->_params);
+	}
+
+	public function jsonSerialize(): array
+	{
+		return $this->_params;
 	}
 
 	public function __debugInfo(): array

--- a/urlsearchparams.php
+++ b/urlsearchparams.php
@@ -22,7 +22,11 @@ class URLSearchParams implements URLSearchParamsInterface, JsonSerializable
 
 	public function __toString(): string
 	{
-		return http_build_query($this->_params);
+		if (count($this->_params) === 0) {
+			return '';
+		} else {
+			return http_build_query($this->_params);
+		}
 	}
 
 	public function jsonSerialize(): array


### PR DESCRIPTION
## Static method for determining request URLs. Resolves #2 

### List of significant changes made
- Add static method for determining request URLs with fallbacks for CLI usage
- Enforce better compatibility with `JS` for URL & `URLSearchParams` by adding `__toString()` & `jsonSerilize(): string` to interface
- Ensure return values of `getHash()` & `getSearch()` match JS versions
