### PR TITLE
Implement serializable CURLFile class

### DIFF
--- a/file.php
+++ b/file.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace shgysk8zer0\HTTP;
+
+use \shgysk8zer0\HTTP\Interfaces\FileInterface;
+
+use \shgysk8zer0\HTTP\Traits\FileTrait;
+
+use \JsonSerializable;
+
+use \InvalidArgumentException;
+
+class File implements JsonSerializable, FileInterface
+{
+	use FileTrait;
+
+	final public function __construct(
+		string  $filename,
+		?string $mimetype = null,
+		string  $postname = ''
+	) {
+		if (! $this->_setFile($filename, $mimetype, $postname)) {
+			throw new InvalidArgumentException(sprintf('File %s not found', $filename));
+		}
+	}
+
+	public function jsonSerialize(): array
+	{
+		return [
+			'name'     => $this->getFileName(),
+			'mime'     => $this->getMimeType(),
+			'postname' => $this->getPostFileName(),
+		];
+	}
+
+	public function __debugInfo(): array
+	{
+		return [
+			'name'     => $this->getFileName(),
+			'mime'     => $this->getMimeType(),
+			'postname' => $this->getPostFileName(),
+		];
+	}
+} 

--- a/formdata.php
+++ b/formdata.php
@@ -2,7 +2,7 @@
 
 namespace shgysk8zer0\HTTP;
 
-use \shgysk8zer0\HTTP\Interfaces\{FormDataInterface};
+use \shgysk8zer0\HTTP\Interfaces\{FormDataInterface, FileInterface};
 
 use \JsonSerializable;
 
@@ -74,7 +74,7 @@ class FormData implements FormDataInterface, JsonSerializable, IteratorAggregate
 	{
 		if (! file_exists($filename)) {
 			return false;
-		} elseif (! $file = new CURLFile($filename, $type, $postname)) {
+		} elseif (! $file = new File($filename, $type, $postname)) {
 			return false;
 		} elseif ($append) {
 			return $this->append($file->getPostFilename(), $file);
@@ -104,6 +104,7 @@ class FormData implements FormDataInterface, JsonSerializable, IteratorAggregate
 	public function set(string $name, $value): bool
 	{
 		$this->_data[$name] = [$value];
+
 		return true;
 	}
 
@@ -181,11 +182,16 @@ class FormData implements FormDataInterface, JsonSerializable, IteratorAggregate
 					$n = 0;
 
 					foreach ($values as $value) {
-						$body["{$key}[{$n}]"] = $value;
+						$body["{$key}[{$n}]"] = $value instanceof FileInterface ? $value->getFile() : $value;
 						$n++;
 					}
 				} else {
-					$body[$key] = is_array($values) ? $values[0] : $values;
+					if (is_array($values)) {
+						$value = $values[0];
+						$body[$key] = $value instanceof FileInterface ? $value->getFile() : $value;
+					} else {
+						$body[$key] = $values instanceof FileInterface ? $values->getFile() : $values;
+					}
 				}
 			}
 

--- a/interfaces/fileinterface.php
+++ b/interfaces/fileinterface.php
@@ -1,0 +1,25 @@
+<?php
+namespace shgysk8zer0\HTTP\Interfaces;
+
+use \Serializable;
+
+use \CURLFile;
+
+interface FileInterface extends Serializable
+{
+	public function __construct(string $filename, ?string $mimetype = null, string $postname = '');
+
+	public function jsonSerialize(): array;
+
+	public function getFile(): CURLFile;
+
+	public function getFilename(): string;
+
+	public function getMimeType(): string;
+
+	public function setMimeType(string $mime): void;
+
+	public function getPostFilename():? string;
+
+	public function setPostFilename(string $name): void;
+}

--- a/request.php
+++ b/request.php
@@ -3,23 +3,23 @@
 namespace shgysk8zer0\HTTP;
 
 use \shgysk8zer0\HTTP\Interfaces\{
-	RequestInterface,
-	ResponseInterface,
+	BodyInterface,
 	FormDataInterface,
 	HeadersInterface,
-	BodyInterface,
+	RequestInterface,
+	ResponseInterface,
 };
 
 use \shgysk8zer0\HTTP\Abstracts\HTTPStatusCodes;
 
 use \shgysk8zer0\PHPAPI\Interfaces\{
-	LoggerAwareInterface,
 	CacheAwareInterface,
+	LoggerAwareInterface,
 };
 
 use \shgysk8zer0\PHPAPI\Traits\{
-	LoggerAwareTrait,
 	CacheAwareTrait,
+	LoggerAwareTrait,
 };
 
 use \shgysk8zer0\PHPAPI\{NullLogger, NullCache};
@@ -240,11 +240,6 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 			curl_setopt($ch, CURLOPT_HEADER,         true);
 			curl_setopt($ch, CURLOPT_SAFE_UPLOAD,    true);
 
-			foreach ($this->getHeaders()->entries() as $entry) {
-				$headers[] = "{$entry[0]}: {$entry[1]}";
-			}
-
-			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 			// @TODO implement cookies & auth
 
 			switch($this->getMethod()) {
@@ -262,6 +257,13 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 				default:
 					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $this->getMethod());
 			}
+
+
+			foreach ($this->getHeaders()->entries() as $entry) {
+				$headers[] = "{$entry[0]}: {$entry[1]}";
+			}
+
+			curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
 			if (isset($this->_body)) {
 				if ($type = $this->getBody()->getContentTypeHeader()) {

--- a/traits/filetrait.php
+++ b/traits/filetrait.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace shgysk8zer0\HTTP\Traits;
+
+use \CURLFile;
+
+use \RuntimeException;
+
+use \InvalidArgumentException;
+
+trait FileTrait
+{
+	private $_file = null;
+
+	private $_filepath = null;
+
+	public function serialize(): string
+	{
+		return serialize([
+			'filepath' => $this->_getFilePath(),
+			'mimetype' => $this->getMimeType(),
+			'postname' => $this->getPostFilename(),
+		]);
+	}
+
+	public function unserialize($data): void
+	{
+		if (! $parsed = unserialize($data)) {
+			throw new RuntimeException('Error unserializing File');
+		} elseif (! $this->_setFile($parsed['filepath'], $parsed['mimetype'], $parsed['postname'])) {
+			throw new InvalidArgumentException(sprintf('File %s not found', $parsed['filename']));
+		}
+	}
+
+	public function getFile(): CURLFile
+	{
+		return $this->_file;
+	}
+
+	public function getFilename(): string
+	{
+		return $this->getFile()->getFilename();
+	}
+
+	public function getMimeType(): string
+	{
+		return $this->getFile()->getMimeType();
+	}
+
+	public function setMimeType(string $mime): void
+	{
+		$this->getFile()->setMimeType($mime);
+	}
+
+	public function getPostFilename():? string
+	{
+		return $this->getFile()->getPostFilename();
+	}
+
+	public function setPostFilename(string $name): void
+	{
+		$this->getFile()->setPostFilename($name);
+	}
+
+	final protected function _setFile(
+		string  $filename,
+		?string $mimetype = null,
+		string  $postname = ''
+	): bool
+	{
+		if (file_exists($filename)) {
+			if (is_null($mimetype)) {
+				// @TODO determine mime type from file info
+				$mimetype = mime_content_type($filename);
+			}
+
+			$this->_file = new CURLFile($filename, $mimetype, $postname);
+			$this->_filepath = realpath($filename);
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	final protected function _getFilePath():? string
+	{
+		return $this->_filepath;
+	}
+}


### PR DESCRIPTION
Does not extend `CURLFile` but is rather a wrapper around it.

- `FormData::attach()` now uses `File` instead of `CURLFile`
- Updates `FormData` to set the corresponding `CURLFile` instead of `File` itself
- Adds interface & trait for reusability

Resolves #18