### PR TITLE
Feature/23

### DIFF
--- a/interfaces/headersinterface.php
+++ b/interfaces/headersinterface.php
@@ -10,6 +10,8 @@ interface HeadersInterface extends Serializable
 
 	public function get(string $name):? string;
 
+	public function getAll(string $name): array;
+
 	public function set(string $name, string $value): bool;
 
 	public function has(string $name): bool;
@@ -22,5 +24,5 @@ interface HeadersInterface extends Serializable
 
 	public function entries(): iterable;
 
-	public static function fromRequestHeaders(string ...$include):? HeadersInterface;
+	public static function fromRequestHeaders(string ...$include): HeadersInterface;
 }

--- a/interfaces/requestinterface.php
+++ b/interfaces/requestinterface.php
@@ -44,6 +44,14 @@ interface RequestInterface extends Serializable
 
 	public function setMethod(string $val): void;
 
+	public function getRedirect(): string;
+
+	public function setRedirect(string $val): void;
+
+	public function getReferrer(): string;
+
+	public function setReferrer(string $val): void;
+
 	public function getUrl():? string;
 
 	public function setUrl(string $val): void;

--- a/interfaces/requestinterface.php
+++ b/interfaces/requestinterface.php
@@ -4,9 +4,15 @@ namespace shgysk8zer0\HTTP\Interfaces;
 
 use \Serializable;
 
+use \DateInterval;
+
 interface RequestInterface extends Serializable
 {
 	public function __construct(string $url, array $init = []);
+
+	public function __get(string $name);
+
+	public function __invoke(?int $timeout = null, ?CacheInterface $cache = null):? ResponseInterface;
 
 	public function text():? string;
 
@@ -16,9 +22,25 @@ interface RequestInterface extends Serializable
 
 	public function getBody():? BodyInterface;
 
-	public function setBody(BodyInterface $val): void;
+	public function setBody(?BodyInterface $val): void;
+
+	public function getCacheMode(): string;
+
+	public function setCacheMode(string $val): void;
+
+	public function getCredentials(): string;
+
+	public function setCredentials(string $val): void;
+
+	public function getExpiration(): DateInterval;
+
+	public function setExpiration(?DateInterval $val = null): void;
 
 	public function getMethod(): string;
+
+	public function getHeaders(): HeadersInterface;
+
+	public function setHeaders(HeadersInterface $val): void;
 
 	public function setMethod(string $val): void;
 
@@ -26,5 +48,12 @@ interface RequestInterface extends Serializable
 
 	public function setUrl(string $val): void;
 
-	public function send():? ResponseInterface;
+	/**
+	 * Sends the HTTP request and returns the response
+	 * @TODO Implement caching
+	 * @return ResponseInterface
+	 */
+	public function send(?int $timeout = null):? ResponseInterface;
+
+	public static function fromRequest(): RequestInterface;
 }

--- a/interfaces/responseinterface.php
+++ b/interfaces/responseinterface.php
@@ -6,6 +6,8 @@ use \Serializable;
 
 interface ResponseInterface extends Serializable
 {
+	public function redirect(string $url, int $status = 302): ResponseInterface;
+
 	public function getStatus(): int;
 
 	public function getStatusText():? string;
@@ -17,6 +19,10 @@ interface ResponseInterface extends Serializable
 	public function getHeaders():? HeadersInterface;
 
 	public function setHeaders(HeadersInterface $val): void;
+
+	public function getRedirected(): bool;
+
+	public function setRedirected(bool $val): void;
 
 	public function getBody():? BodyInterface;
 

--- a/request.php
+++ b/request.php
@@ -4,6 +4,7 @@ namespace shgysk8zer0\HTTP;
 
 use \shgysk8zer0\HTTP\Interfaces\{
 	BodyInterface,
+	CacheInterface,
 	FormDataInterface,
 	HeadersInterface,
 	RequestInterface,
@@ -47,6 +48,22 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 		'DELETE',
 	];
 
+	// @SEE https://developer.mozilla.org/en-US/docs/Web/API/Request/cache
+	private const CACHE_MODES = [
+		'default',
+		'no-cache',
+		'reload',
+		'force-cache',
+		'only-if-cached',
+		'no-store',
+	];
+
+	private const CREDENTIALS = [
+		'omit',
+		'include',
+		'same-orign',
+	];
+
 	private $_url = null;
 
 	private $_headers = null;
@@ -54,6 +71,12 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 	private $_method = 'GET';
 
 	private $_body   = null;
+
+	private $_cache = 'no-store';
+
+	private $_credentials = 'omit';
+
+	private $_expiration = null;
 
 	public function __construct(string $url, array $init = [])
 	{
@@ -70,82 +93,111 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 			$this->setBody($init['body']);
 		}
 
-		if (array_key_exists('headers', $init)) {
-			if (is_array($init['headers'])) {
-				$this->setHeaders(new Headers($init['headers']));
-			} elseif (is_object($init['headers'])) {
-				if ($init['headers'] instanceof HeadersInterface) {
-					$this->setHeaders($init['headers']);
-				} else {
-					$this->setHeaders(new Headers(get_object_vars($init['headrs'])));
-				}
-			} else {
-				throw new InvalidArgumentException('Unsupported init data for Headers');
-			}
-		} else {
+		if (array_key_exists('cache', $init)) {
+			$this->setCacheMode($init['cache']);
+		}
+
+		if (array_key_exists('credentials', $init)) {
+			$this->setCredentials($init['credentials']);
+		}
+
+		if (! array_key_exists('headers', $init)) {
 			$this->setHeaders(new Headers());
+		} elseif (is_array($init['headers'])) {
+			$this->setHeaders(new Headers($init['headers']));
+		} elseif (! is_object($init['headers'])) {
+			throw new InvalidArgumentException('Unsupported init data for Headers');
+		} elseif ($init['headers'] instanceof HeadersInterface) {
+			$this->setHeaders($init['headers']);
+		} else {
+			$this->setHeaders(new Headers(get_object_vars($init['headers'])));
 		}
 	}
 
 	public function __debugInfo(): array
 	{
 		return [
-			'url'     => $this->getUrl(),
-			'method'  => $this->getMethod(),
-			'headers' => $this->getHeaders(),
-			'body'    => $this->getBody(),
+			'url'         => $this->getUrl(),
+			'method'      => $this->getMethod(),
+			'headers'     => $this->getHeaders(),
+			'body'        => $this->getBody(),
+			'cache'       => $this->getCacheMode(),
+			'credentials' => $this->getCredentials(),
 		];
 	}
 
 	public function serialize(): string
 	{
 		return serialize([
-			'url'     => $this->getUrl(),
-			'method'  => $this->getMethod(),
-			'headers' => $this->getHeaders(),
-			'body'    => $this->getBody(),
+			'url'         => $this->getUrl(),
+			'method'      => $this->getMethod(),
+			'headers'     => $this->getHeaders(),
+			'body'        => $this->getBody(),
+			'cache'       => $this->getCacheMode(),
+			'credentials' => $this->getCredentials(),
+			'expiration'  => $this->getExpiration(),
 		]);
 	}
 
 	public function unserialize($data): void
 	{
 		[
-			'url'     => $url,
-			'method'  => $method,
-			'headers' => $headers,
-			'body'    => $body,
+			'url'         => $url,
+			'method'      => $method,
+			'headers'     => $headers,
+			'body'        => $body,
+			'cache'       => $cache,
+			'credentials' => $credentials,
+			'expiration'  => $expiration,
 		] = array_merge([
-			'url'     => null,
-			'method'  => null,
-			'headers' => null,
-			'body'    => null,
+			'url'         => null,
+			'method'      => null,
+			'headers'     => new Headers(),
+			'body'        => null,
+			'cache'       => 'default',
+			'credentials' => 'omit',
+			'expiration'  => null,
 		], unserialize($data));
 
 		$this->setUrl($url);
 		$this->setMethod($method);
 		$this->setHeaders($headers);
 		$this->setBody($body);
+		$this->setCacheMode($cache);
+		$this->setCredentials($credentials);
+		$this->setExpiration($expiration);
 	}
 
 	public function jsonSerialize(): array
 	{
 		return [
-			'url'     => $this->getUrl(),
-			'method'  => $this->getMethod(),
-			'headers' => $this->getHeaders(),
-			'body'    => $this->getBody(),
+			'url'         => $this->getUrl(),
+			'method'      => $this->getMethod(),
+			'headers'     => $this->getHeaders(),
+			'body'        => $this->getBody(),
+			'cache'       => $this->getCacheMode(),
+			'credentials' => $this->getCredentials(),
 		];
 	}
 
 	public function __get(string $name)
 	{
 		switch($name) {
-			case 'url': return $this->getUrl();
-			case 'method': return $this->getMethod();
+			case 'url':     return $this->getUrl();
+			case 'method':  return $this->getMethod();
 			case 'headers': return $this->getHeaders();
-			case 'body': return $this->getBody();
+			case 'body':    return $this->getBody();
 			default: throw new InvalidArgumentException(sprintf('Invalid property: %s', $name));
 		}
+	}
+
+	public function __invoke(?int $timeout = null, ?CacheInterface $cache = null):? ResponseInterface
+	{
+		if (isset($cache)) {
+			$this->setCache($cache);
+		}
+
+		return $this->send($timeout);
 	}
 
 	public function text():? string
@@ -180,9 +232,55 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 		return $this->_body;
 	}
 
-	public function setBody(BodyInterface $val): void
+	public function setBody(?BodyInterface $val): void
 	{
 		$this->_body = $val;
+	}
+
+	public function getCacheMode(): string
+	{
+		return $this->_cache;
+	}
+
+	public function setCacheMode(string $val): void
+	{
+		if (in_array($val, self::CACHE_MODES)) {
+			$this->_cache = $val;
+		} else {
+			throw new InvalidArgumentException(sprintf('Invalid cache mode: %s', $val));
+		}
+	}
+
+	public function getCredentials(): string
+	{
+		return $this->_credentials;
+	}
+
+	public function setCredentials(string $val): void
+	{
+		if (in_array($val, self::CREDENTIALS)) {
+			$this->_credentials = $val;
+		} else {
+			throw new InvalidArgumentException(sprintf('Invalid credentials mode: %s', $val));
+		}
+	}
+
+	public function getExpiration(): DateInterval
+	{
+		if (isset($this->_expiration)) {
+			return $this->_expiration;
+		} else {
+			return new DateInterval('PT1H');
+		}
+	}
+
+	public function setExpiration(?DateInterval $val = null): void
+	{
+		if (isset($val)) {
+			$this->_expiration = $val;
+		} else {
+			$this->_expiration = null;
+		}
 	}
 
 	public function getMethod(): string
@@ -192,7 +290,13 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 
 	public function getHeaders(): HeadersInterface
 	{
-		return $this->_headers;
+		if ($this->getCredentials() !== 'omit') {
+			return $this->_headers;
+		} else {
+			$copy = clone($this->_headers);
+			$copy->delete('cookie');
+			return $copy;
+		}
 	}
 
 	public function setHeaders(HeadersInterface $val): void
@@ -222,7 +326,103 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 	 * @TODO Implement caching
 	 * @return ResponseInterface
 	 */
-	public function send(int $timeout = 2000):? ResponseInterface
+	public function send(?int $timeout = null):? ResponseInterface
+	{
+		if ($this->getMethod() === 'GET') {
+			switch($this->getCacheMode()) {
+				// @TODO determine cache expiration
+				case 'default':
+					if ($this->cache->has($this->getUrl())) {
+						// @TODO check staleness
+						return $this->cache->get($this->getUrl());
+					} else {
+						$resp = $this->_fetch($timeout);
+
+						if (isset($resp) and $resp->getOk()) {
+							$this->cache->set($this->getUrl(), $resp, $this->getExpiration());
+						}
+
+						return $resp;
+					}
+
+				case 'no-store':
+					return $this->_fetch($timeout);
+
+				case 'reload':
+					$resp = $this->_fetch($timeout);
+
+					if (isset($resp) and $resp->getOk()) {
+						$this->cache->set($this->getUrl(), $resp, $this->getExpiration());
+					}
+
+					return $resp;
+
+				case 'no-cache':
+					if ($this->cache->has($this->getUrl())) {
+						// @TODO check if stale
+						return $this->cache->get($this->getUrl());
+					} else {
+						$resp = $this->_fetch($timeout);
+
+						if (isset($resp) and $resp->getOk()) {
+							$this->cache->set($this->getUrl(), $resp, $this->getExpiration());
+						}
+
+						return $resp;
+					}
+
+				case 'force-cache':
+					if ($this->cache->has($this->getUrl())) {
+						return $this->cache->get($this->getUrl());
+					} else {
+						$resp = $this->_fetch($timeout);
+
+						if (isset($resp) and $resp->getOk()) {
+							$this->cache->set($this->getUrl(), $resp, $this->getExpiration());
+						}
+
+						return $resp;
+					}
+
+				case 'only-if-cached':
+					$fallback = new Response();
+					$fallback->setUrl($this->getUrl());
+					$fallback->setBody(new Body('Gateway Timeout'));
+					$fallback->setHeaders(new Headers(['Content-Type' => 'text/plain']));
+					$fallback->setStatus($this::GATEWAY_TIMEOUT);
+
+					return $this->cache->get($this->getUrl(), $fallback);
+			}
+		} else {
+			return $this->_fetch($timeout);
+		}
+	}
+
+	public static function fromRequest(): RequestInterface
+	{
+		$req = new self(URL::requestUrl(), [
+			'headers'     => Headers::fromRequestHeaders(),
+			'credentials' => 'include',
+		]);
+
+		if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
+			$req->setMethod($_SERVER['REQUEST_METHOD']);
+
+			if ($req->getMethod() === 'POST') {
+				$req->setBody(new FormData($_POST));
+			}
+		} else {
+			$req->setMethod('GET');
+		}
+
+		if (! $req->headers->has('cookie')) {
+			$req->setCredentials('omit');
+		}
+
+		return $req;
+	}
+
+	private function _fetch(?int $timeout = null):? ResponseInterface
 	{
 		try {
 			if (in_array($this->getMethod(), self::NO_BODY) and isset($this->_body)) {
@@ -235,11 +435,13 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_HEADEROPT,      CURLHEADER_UNIFIED);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-			curl_setopt($ch, CURLOPT_TIMEOUT_MS,     $timeout);
 			curl_setopt($ch, CURLOPT_USERAGENT,      __CLASS__);
 			curl_setopt($ch, CURLOPT_HEADER,         true);
 			curl_setopt($ch, CURLOPT_SAFE_UPLOAD,    true);
 
+			if (is_int($timeout)) {
+				curl_setopt($ch, CURLOPT_TIMEOUT_MS,     $timeout);
+			}
 			// @TODO implement cookies & auth
 			$headers = [];
 
@@ -259,6 +461,10 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 					curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $this->getMethod());
 			}
 
+
+			if ($this->getCredentials() !== 'include') {
+				$this->getHeaders()->delete('cookie');
+			}
 
 			foreach ($this->getHeaders()->entries() as $entry) {
 				$headers[] = "{$entry[0]}: {$entry[1]}";
@@ -288,34 +494,57 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 
 			$body = curl_exec($ch);
 
-			if (curl_errno($ch) !== CURLE_OK) {
-				$errno = curl_errno($ch);
+			$errno = curl_errno($ch);
+
+			if ($errno !== CURLE_OK) {
 				switch ($errno) {
 					case CURLE_OPERATION_TIMEDOUT:
-					$this->logger->error('{method} {url} timeout [{timeout}ms]', [
-						'method'  => $this->getMethod(),
-						'url'     => $this->getUrl(),
-						'timeout' => $timeout,
-					]);
-					break;
+						$this->logger->error('{method} {url} timeout [{timeout}ms]', [
+							'method'  => $this->getMethod(),
+							'url'     => $this->getUrl(),
+							'timeout' => $timeout,
+						]);
+						$resp = new Response();
+						$resp->setStatus(self::GATEWAY_TIMEOUT);
+						$resp->setHeaders(new Headers(['Content-Type' => 'text/plain']));
+						$resp->setUrl($this->getUrl());
+						$resp->setBody(new Body('Gateway Timeout'));
+						return $resp;
+						break;
+					default:
+						$this->logger->error('cURL error [{errno}] "{{error}', [
+							'errno' => $errno,
+							'error' => curl_error($ch),
+						]);
+						$resp = new Response();
+						$resp->setStatus(self::BAD_GATEWAY);
+						$resp->setHeaders(new Headers(['Content-Type' => 'text/plain']));
+						$resp->setBody(new Body('An unknown error occured'));
 
+						return $resp;
 				}
 
-				throw new RuntimeException(curl_error($ch), $errno);
+				curl_close($ch);
+
+				return null;
 			} else {
 				// handle success
-				$status = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
-				$url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-				$cookies = curl_getinfo($ch, CURLINFO_COOKIELIST);
+				$status      = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+				$url         = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+				$cookies     = curl_getinfo($ch, CURLINFO_COOKIELIST);
 				$header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-				$headers = Headers::parseFromCurlResponse(substr($body, 0, $header_size));
-				$body = substr($body, $header_size);
+				$headers     = Headers::parseFromCurlResponse(substr($body, 0, $header_size));
+				$body        = substr($body, $header_size);
+
+				if ($this->getCredentials() !== 'include') {
+					$headers->delete('cookie');
+				}
 
 				$response = new Response();
 				$response->setLogger($this->logger);
 				$response->setUrl($url);
 
-				if ($this->getMethod() !== 'HEAD') {
+				if (! in_array($this->getMethod(), ['HEAD'])) {
 					$response->setBody(new Body($body));
 				}
 
@@ -341,6 +570,22 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 
 			return null;
 		}
+	}
 
+	private function _isStale(int $timeout = 200): bool
+	{
+		return false;
+		/*if ($this->getMethod() === 'GET') {
+			$cp = clone($this);
+			$cp->setMethod('HEAD');
+
+			if ($resp = $cp->send(500)) {
+				return $resp->isOk();
+			} else {
+				return true;
+			}
+		} else {
+			return true;
+		}*/
 	}
 }


### PR DESCRIPTION
- `Headers::getAll()` now guaranteed to return an array
- Fix setting "Date" header (no-split on ",")
- Do not allow splitting headers into > 2 components (key: value)
- Rewrite `Headers::fromRequestHeaders()`
- Provide getters & setters for cache & credentials
- For compatibility with `CacheInterface`, use CacheMethod instead of just cache
- Strip cookie headers if credentials is omit
- Implement basic handling of caching based solely on given expiration for GET requests
- Add static method to create a Request object from an HTTP request
-  Referrer & Redirect for Request
- Add Redirect & Redirected to Response

Resolves #23 