### PR TITLE
Match `Response.constructor()`

### DIFF
--- a/interfaces/responseinterface.php
+++ b/interfaces/responseinterface.php
@@ -6,6 +6,8 @@ use \Serializable;
 
 interface ResponseInterface extends Serializable
 {
+	public function __construct(?BodyInterface $body = null, array $init = []);
+
 	public function redirect(string $url, int $status = 302): ResponseInterface;
 
 	public function getStatus(): int;

--- a/request.php
+++ b/request.php
@@ -619,17 +619,22 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 					$headers->delete('cookie');
 				}
 
-				$response = new Response();
-				$response->setLogger($this->logger);
-				$response->setUrl($url);
-				$response->setRedirected($response->getUrl() !== $this->getUrl());
-
-				if (! in_array($this->getMethod(), ['HEAD'])) {
-					$response->setBody(new Body($body));
+				if (! in_array($this->getMethod(), ['HEAD', 'OPTIONS'])) {
+					$response = new Response(new Body($body), [
+						'status'  => $status ?? self::INTERNAL_SERVER_ERROR,
+						'headers' => $headers,
+					]);
+				} else {
+					$response = new Response(null, [
+						'status'  => $status ?? self::INTERNAL_SERVER_ERROR,
+						'headers' => $headers,
+					]);
 				}
 
-				$response->setStatus($status);
-				$response->setHeaders($headers);
+				$response->setUrl($url);
+				$response->setRedirected($response->getUrl() !== $this->getUrl());
+				$response->setLogger($this->logger);
+				$response->setCache($this->cache);
 			}
 
 			curl_close($ch);

--- a/response.php
+++ b/response.php
@@ -44,11 +44,27 @@ class Response extends HTTPStatusCodes implements ResponseInterface, LoggerAware
 
 	private $_redirected = false;
 
-	public function __construct()
+	public function __construct(?BodyInterface $body = null, array $init = [])
 	{
+		$this->setBody($body);
 		$this->setLogger(new NullLogger());
 		$this->setCache(new NullCache());
-		$this->setHeaders(new Headers());
+
+		if (! array_key_exists('headers', $init)) {
+			$this->setHeaders(new Headers());
+		} elseif (is_array($init['headers'])) {
+			$this->setHeaders(new Headers($init['headers']));
+		} elseif (! is_object($init['headers'])) {
+			throw new InvalidArgumentException('Unsupported init data for Headers');
+		} elseif ($init['headers'] instanceof HeadersInterface) {
+			$this->setHeaders($init['headers']);
+		} else {
+			$this->setHeaders(new Headers(get_object_vars($init['headers'])));
+		}
+
+		if (array_key_exists('status', $init)) {
+			$this->setStatus($init['status']);
+		}
 	}
 
 	public function serialize(): string


### PR DESCRIPTION
`Response::__construct` now matches `Response.constructor`, allowing creating preset with body, status, & Headers.
