### PR TITLE
Misc. bug fixes

### DIFF
--- a/request.php
+++ b/request.php
@@ -461,10 +461,11 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 					}
 
 				case 'only-if-cached':
-					$fallback = new Response();
+					$fallback = new Response(new Body('Gateway Timeout'), [
+						'headers' => new Headers(['Content-Type' => 'text/plain']),
+						'status'  => self::GATEWAY_TIMEOUT,
+					]);
 					$fallback->setUrl($this->getUrl());
-					$fallback->setBody(new Body('Gateway Timeout'));
-					$fallback->setHeaders(new Headers(['Content-Type' => 'text/plain']));
 					$fallback->setStatus($this::GATEWAY_TIMEOUT);
 
 					return $this->cache->get($this->getUrl(), $fallback);
@@ -688,11 +689,11 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 							'url'     => $this->getUrl(),
 							'timeout' => $timeout,
 						]);
-						$resp = new Response();
-						$resp->setStatus(self::GATEWAY_TIMEOUT);
-						$resp->setHeaders(new Headers(['Content-Type' => 'text/plain']));
+						$resp = new Response(new Body('Gateway Timeout'), [
+							'headers' => new Headers(['Content-Type' => 'text/plain']),
+							'status'  => self::GATEWAY_TIMEOUT,
+						]);
 						$resp->setUrl($this->getUrl());
-						$resp->setBody(new Body('Gateway Timeout'));
 						return $resp;
 						break;
 					default:
@@ -700,11 +701,12 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 							'errno' => $errno,
 							'error' => curl_error($ch),
 						]);
-						$resp = new Response();
-						$resp->setStatus(self::BAD_GATEWAY);
-						$resp->setHeaders(new Headers(['Content-Type' => 'text/plain']));
-						$resp->setBody(new Body('An unknown error occured'));
+						$resp = new Response(new Body('An unknown error occured'), [
+							'headers' => new Headers(['Content-Type' => 'text/plain']),
+							'status'  => self::BAD_GATEWAY,
+						]);
 
+						$resp->setUrl($this->getUrl());
 						return $resp;
 				}
 

--- a/request.php
+++ b/request.php
@@ -616,6 +616,7 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 			curl_setopt($ch, CURLOPT_HEADEROPT,      CURLHEADER_UNIFIED);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
 			curl_setopt($ch, CURLOPT_USERAGENT,      self::USER_AGENT);
 			curl_setopt($ch, CURLOPT_HEADER,         true);
 			curl_setopt($ch, CURLOPT_SAFE_UPLOAD,    true);
@@ -695,7 +696,7 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 						return $resp;
 						break;
 					default:
-						$this->logger->error('cURL error [{errno}] "{{error}', [
+						$this->logger->error('cURL error [{errno}] "{error}', [
 							'errno' => $errno,
 							'error' => curl_error($ch),
 						]);
@@ -725,7 +726,7 @@ class Request extends HTTPStatusCodes implements RequestInterface, LoggerAwareIn
 				} else {
 					$cookies = Cookies::parseHeader($headers->get('cookie'));
 				}
-				\shgysk8zer0\PHPAPI\Console::info($cookies);
+
 				if (! in_array($this->getMethod(), ['HEAD', 'OPTIONS'])) {
 					$response = new Response(new Body($body), [
 						'status'  => $status ?? self::INTERNAL_SERVER_ERROR,

--- a/traits/responsetrait.php
+++ b/traits/responsetrait.php
@@ -84,22 +84,27 @@ trait ResponseTrait
 	{
 		// @TODO Finish filling out status code text
 		switch($this->getStatus()) {
-			case HTTP::CONT: return 'Continue';
-			case HTTP::SWITCHING_PROTOCOLS: return 'Switching Protocols';
-			case HTTP::PROCESSING: return 'Processing';
-			case HTTP::OK: return 'Ok';
-			case HTTP::CREATED: return 'Created';
-			case HTTP::ACCEPTED: return 'Accepted';
-			case HTTP::NON_AUTHORITATIVE: return 'Non-Authoritative';
-			case HTTP::NO_CONTENT: return 'No Content';
-			case HTTP::BAD_REQUEST: return 'Bad Request';
-			case HTTP::UNAUTHORIZED: return 'Unauthorized';
-			case HTTP::PAYMENT_REQUIRED: return 'Payment Required';
-			case HTTP::FORBIDDEN: return 'Forbidden';
-			case HTTP::NOT_FOUND: return 'Not Found';
-			case HTTP::METHOD_NOT_ALLOWED: return 'Not Found';
-			case HTTP::INTERNAL_SERVER_ERROR: return 'Internal Server Error';
-			default: return 'Unknown';
+			case HTTP::CONT:                            return 'Continue';
+			case HTTP::SWITCHING_PROTOCOLS:             return 'Switching Protocols';
+			case HTTP::PROCESSING:                      return 'Processing';
+			case HTTP::OK:                              return 'Ok';
+			case HTTP::CREATED:                         return 'Created';
+			case HTTP::ACCEPTED:                        return 'Accepted';
+			case HTTP::NON_AUTHORITATIVE:               return 'Non-Authoritative';
+			case HTTP::NO_CONTENT:                      return 'No Content';
+			case HTTP::BAD_REQUEST:                     return 'Bad Request';
+			case HTTP::UNAUTHORIZED:                    return 'Unauthorized';
+			case HTTP::PAYMENT_REQUIRED:                return 'Payment Required';
+			case HTTP::FORBIDDEN:                       return 'Forbidden';
+			case HTTP::NOT_FOUND:                       return 'Not Found';
+			case HTTP::METHOD_NOT_ALLOWED:              return 'Not Found';
+			case HTTP::NOT_IMPLEMENTED:                 return 'Not Implemented';
+			case HTTP::BAD_GATEWAY:                     return 'Bad Gateway';
+			case HTTP::REQUEST_HEADER_FILEDS_TOO_LARGE: return 'Request Header Fields Too Large';
+			case HTTP::INTERNAL_SERVER_ERROR:           return 'Internal Server Error';
+			case HTTP::SERVICE_UNAVAILABLE:             return 'Service Unavailable';
+			case HTTP::GATEWAY_TIMEOUT:                 return 'Gateway Timeout';
+			default:                                    return 'Unknown';
 		}
 	}
 

--- a/traits/responsetrait.php
+++ b/traits/responsetrait.php
@@ -27,6 +27,8 @@ use \shgysk8zer0\PHPAPI\Interfaces\{
 	CacheAwareInterface,
 };
 
+use \InvalidArgumentException;
+
 trait ResponseTrait
 {
 	private $_status = HTTP::OK;
@@ -45,6 +47,7 @@ trait ResponseTrait
 	{
 		switch($name) {
 			case 'url':        return $this->getUrl();
+			case 'ok':         return $this->getOk();
 			case 'status':     return $this->getStatus();
 			case 'statusText': return $this->getStatusText();
 			case 'headers':    return $this->getHeaders();

--- a/urlsearchparams.php
+++ b/urlsearchparams.php
@@ -29,7 +29,19 @@ class URLSearchParams implements URLSearchParamsInterface, JsonSerializable
 		if (count($this->_params) === 0) {
 			return '';
 		} else {
-			return http_build_query($this->_params);
+			$params = [];
+
+			foreach ($this->keys() as $key) {
+				$value = $this->getAll($key);
+
+				if (count($value) === 1) {
+					$params[$key] = $value[0];
+				} else {
+					$params[$key] = $value;
+				}
+			}
+
+			return http_build_query($params);
 		}
 	}
 


### PR DESCRIPTION
- Add explicit `CURLOPT_SSL_VERIFYPEER`
- Fix logging format on cURL errors
- Remove Console logging of cookies
- Add missing `Response::ok` to getter
- Fix stringifying `URLSearchParams`
- Use `Response::__constructor` args when creating responses for requests